### PR TITLE
Postgres refactors

### DIFF
--- a/src/Postgres.chpl
+++ b/src/Postgres.chpl
@@ -22,7 +22,8 @@ module Postgres{
     use Types;
     use Map;
     use List;
-
+    use SysCTypes;
+    
     require "libpq-fe.h","-lpq";
     require "stdio.h";
 

--- a/src/Postgres.chpl
+++ b/src/Postgres.chpl
@@ -23,7 +23,6 @@ module Postgres{
     use Map;
     use List;
     use SysCTypes;
-    
     require "libpq-fe.h","-lpq";
     require "stdio.h";
 


### PR DESCRIPTION
Resolve issue of missing imports.

It does generate the following error :- 

./Postgres.chpl:287: error: 'c_int' undeclared (first use this function)
./Postgres.chpl:951: error: 'c_int' undeclared (first use this function)